### PR TITLE
Fixes to eliminate the need for `pythonpath` modifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
     "zipp==3.15.0",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = "src"

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 [[package]]
 name = "coauthor-interface"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiosignal" },


### PR DESCRIPTION
A couple of changes were required:

1) `__init__.py` was in the wrong directory.
2) It looks like `pyproject.toml` was created outside of `uv init`, so the `build-system` attributes were not provided. `uv` uses these attributes to install the package as a local dependency when running `uv sync`.