### PR TITLE
add tests for missing access code

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -98,3 +98,27 @@ def test_start_session_success(
     assert "session_id" in data.keys()
     assert "example_text" in data.keys()
     assert "prompt_text" in data.keys()
+
+
+@patch("coauthor_interface.backend.api_server.read_access_codes")
+@patch("coauthor_interface.backend.api_server.read_prompts")
+@patch("coauthor_interface.backend.api_server.read_examples")
+@patch("coauthor_interface.backend.api_server.print_current_sessions")
+def test_start_session_no_access_code_provided(
+    mock_print_current_sessions,
+    mock_read_examples,
+    mock_read_prompts,
+    mock_read_access_codes,
+    client,
+):
+    # Arrange: mock data
+    mock_read_access_codes.return_value = {"valid_access_code": MagicMock()}
+
+    payload = {"accessCode": ""}  # Simulate missing or empty access code
+
+    response = client.post("/api/start_session", json=payload)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert not data["status"]
+    assert "Invalid access code: (not provided)" in data["message"]


### PR DESCRIPTION
## :pencil: Description
Add testing for the start_session api route when access code is missing or not provided

## :gear: Work Item
https://dev.azure.com/gt-sse-center/CoAuthor/_workitems/edit/689/

## :movie_camera: Demo
<img width="1046" alt="Screenshot 2025-04-29 at 11 36 50 AM" src="https://github.com/user-attachments/assets/f9273c10-710c-4b15-a33a-8dd850ba1804" />
