### PR TITLE
[692] adding NONE to the InterventionEnum and tests

### DIFF
--- a/src/coauthor_interface/backend/PluginInterface.py
+++ b/src/coauthor_interface/backend/PluginInterface.py
@@ -14,7 +14,7 @@ class InterventionEnum(str, Enum):
 class Intervention:
     intervention_type: InterventionEnum
     intervention_message: Optional[str] = None
-    
+
     def __post_init__(self):
         """
         Ensures that an intervention message is provided for all intervention types
@@ -24,8 +24,7 @@ class Intervention:
 
         if self.intervention_type != InterventionEnum.NONE and not self.intervention_message:
             raise ValueError(
-                f"intervention_message is required when intervention_type is "
-                f"{self.intervention_type!r}"
+                f"intervention_message is required when intervention_type is {self.intervention_type!r}"
             )
 
 

--- a/src/coauthor_interface/backend/PluginInterface.py
+++ b/src/coauthor_interface/backend/PluginInterface.py
@@ -1,17 +1,32 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 
 class InterventionEnum(str, Enum):
     # NOTE: this will be updated with new intervention types later. For now, this will only support toasts
-    toast = "toast"
+    TOAST = "toast"
+    NONE = "none"
 
 
 @dataclass
 class Intervention:
     intervention_type: InterventionEnum
-    intervention_message: str
+    intervention_message: Optional[str] = None
+    
+    def __post_init__(self):
+        """
+        Ensures that an intervention message is provided for all intervention types
+        except for 'NONE'. Raises a ValueError if the intervention type is not 'NONE'
+        and the intervention message is empty or None.
+        """
+
+        if self.intervention_type != InterventionEnum.NONE and not self.intervention_message:
+            raise ValueError(
+                f"intervention_message is required when intervention_type is "
+                f"{self.intervention_type!r}"
+            )
 
 
 class Plugin(ABC):

--- a/src/coauthor_interface/thought_toolkit/level_3_plugins.py
+++ b/src/coauthor_interface/thought_toolkit/level_3_plugins.py
@@ -39,7 +39,7 @@ class MajorInsertMindlessEchoPlugin(Plugin):
     @staticmethod
     def intervention_action() -> Intervention:
         return Intervention(
-            intervention_type=InterventionEnum.toast,
+            intervention_type=InterventionEnum.TOAST,
             intervention_message="Detected a major insert mindless echo",
         )
 
@@ -71,6 +71,6 @@ class MinorInsertMindlessEditPlugin(Plugin):
     @staticmethod
     def intervention_action() -> Intervention:
         return Intervention(
-            intervention_type=InterventionEnum.toast,
+            intervention_type=InterventionEnum.TOAST,
             intervention_message="Detected a minor insert mindless edit",
         )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,7 +6,6 @@ from coauthor_interface.backend.PluginInterface import (
 import pytest
 
 
-
 # A basic concrete implementation of Plugin for testing
 class MockPlugin(Plugin):
     @staticmethod
@@ -16,14 +15,14 @@ class MockPlugin(Plugin):
     @staticmethod
     def detection_detected(action) -> bool:
         return action == ["This is true"]
+
     @staticmethod
     def intervention_action() -> Intervention:
         return Intervention(InterventionEnum.TOAST, "This is a toast message")
-    
+
     @staticmethod
     def interventionless_action() -> Intervention:
         return Intervention(InterventionEnum.NONE)
-
 
 
 def test_mock_plugin_name():
@@ -53,11 +52,10 @@ def test_interventionless_action():
     # when the type is NONE, the message should default to None
     assert intervention.intervention_message is None
 
+
 def test_missing_message_error_message():
     with pytest.raises(ValueError) as excinfo:
         # no message for a TOAST should blow up
         Intervention(InterventionEnum.TOAST)
     # it should start with our f-string prefix
-    assert str(excinfo.value).startswith(
-        "intervention_message is required when intervention_type is "
-    )
+    assert str(excinfo.value).startswith("intervention_message is required when intervention_type is ")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,18 +3,27 @@ from coauthor_interface.backend.PluginInterface import (
     InterventionEnum,
     Plugin,
 )
+import pytest
+
 
 
 # A basic concrete implementation of Plugin for testing
 class MockPlugin(Plugin):
-    def get_plugin_name(self) -> str:
+    @staticmethod
+    def get_plugin_name() -> str:
         return "MockPlugin"
 
-    def detection_detected(self, logs) -> bool:
-        return logs == ["This is true"]
+    @staticmethod
+    def detection_detected(action) -> bool:
+        return action == ["This is true"]
+    @staticmethod
+    def intervention_action() -> Intervention:
+        return Intervention(InterventionEnum.TOAST, "This is a toast message")
+    
+    @staticmethod
+    def interventionless_action() -> Intervention:
+        return Intervention(InterventionEnum.NONE)
 
-    def intervention_action(self) -> Intervention:
-        return Intervention(InterventionEnum.toast, "This is a toast message")
 
 
 def test_mock_plugin_name():
@@ -32,5 +41,23 @@ def test_intervention_action():
     plugin = MockPlugin()
     intervention = plugin.intervention_action()
     assert isinstance(intervention, Intervention)
-    assert intervention.intervention_type == InterventionEnum.toast
+    assert intervention.intervention_type == InterventionEnum.TOAST
     assert intervention.intervention_message == "This is a toast message"
+
+
+def test_interventionless_action():
+    plugin = MockPlugin()
+    intervention = plugin.interventionless_action()
+    assert isinstance(intervention, Intervention)
+    assert intervention.intervention_type == InterventionEnum.NONE
+    # when the type is NONE, the message should default to None
+    assert intervention.intervention_message is None
+
+def test_missing_message_error_message():
+    with pytest.raises(ValueError) as excinfo:
+        # no message for a TOAST should blow up
+        Intervention(InterventionEnum.TOAST)
+    # it should start with our f-string prefix
+    assert str(excinfo.value).startswith(
+        "intervention_message is required when intervention_type is "
+    )


### PR DESCRIPTION
## :pencil: Description
Currently, interventions are limited to only showing a toast with a certain message.

We want to add the capability for a plugin to have a detection with no intervention

Work for this:

- add None to intervention Enum

- make sure None type is properly handled

## :gear: Work Item
https://dev.azure.com/gt-sse-center/CoAuthor/_workitems/edit/692

## :movie_camera: Demo
![image](https://github.com/user-attachments/assets/44d02469-967d-478c-8d7f-18d24757bf7e)
