### PR TITLE
686 varun  refactor l3 analysis to use plugin interface

### DIFF
--- a/src/coauthor_interface/backend/parse_all_consolidated.py
+++ b/src/coauthor_interface/backend/parse_all_consolidated.py
@@ -100,7 +100,6 @@ def process_logs(input_file: Path, output_dir: Path) -> None:
 
     # Generate priority-based actions
     custom_priority_list = [plugin.get_plugin_name() for plugin in ACTIVE_PLUGINS]
-
     priority_actions = action_type_priority_sort(custom_priority_list, level_3_actions)
 
     # Save all results
@@ -124,7 +123,7 @@ def process_logs(input_file: Path, output_dir: Path) -> None:
 # 4. 'action_type_with_priority_per_session.json' - Applies priority-based sorting to action types for refined analysis.
 if __name__ == "__main__":
     # Example usage
-    script_dir = Path(__file__).parent
+    script_dir = Path(__file__).parent.parent.parent.parent / "tests"
     input_file = script_dir / "small_logs_for_test.json"
     output_dir = script_dir / "output"
     process_logs(input_file, output_dir)

--- a/src/coauthor_interface/backend/parse_all_consolidated.py
+++ b/src/coauthor_interface/backend/parse_all_consolidated.py
@@ -14,6 +14,8 @@ from coauthor_interface.thought_toolkit.parser_all_levels import (
     parse_level_3_actions,
 )
 
+from coauthor_interface.thought_toolkit.active_plugins import ACTIVE_PLUGINS
+
 
 def parse_level_1_actions(
     coauthor_logs_by_session: dict[str, list[dict[str, Any]]],
@@ -97,10 +99,8 @@ def process_logs(input_file: Path, output_dir: Path) -> None:
     level_3_actions = parse_level_3_actions_from_level_2(level_2_actions)
 
     # Generate priority-based actions
-    custom_priority_list = [
-        "minor_insert_mindless_edit",
-        "major_insert_major_semantic_diff",
-    ]
+    custom_priority_list = [plugin.get_plugin_name() for plugin in ACTIVE_PLUGINS]
+
     priority_actions = action_type_priority_sort(custom_priority_list, level_3_actions)
 
     # Save all results

--- a/src/coauthor_interface/thought_toolkit/active_plugins.py
+++ b/src/coauthor_interface/thought_toolkit/active_plugins.py
@@ -1,0 +1,9 @@
+from coauthor_interface.thought_toolkit.level_3_plugins import (
+    MajorInsertMindlessEchoPlugin,
+    MinorInsertMindlessEditPlugin,
+)
+
+ACTIVE_PLUGINS = [
+    MajorInsertMindlessEchoPlugin(),
+    MinorInsertMindlessEditPlugin(),
+]

--- a/src/coauthor_interface/thought_toolkit/parser_all_levels.py
+++ b/src/coauthor_interface/thought_toolkit/parser_all_levels.py
@@ -3,10 +3,6 @@
 import difflib
 
 from coauthor_interface.thought_toolkit.helper import apply_logs_to_writing
-from coauthor_interface.thought_toolkit.level_3_plugins import (
-    MajorInsertMindlessEchoPlugin,
-    MinorInsertMindlessEditPlugin,
-)
 from coauthor_interface.thought_toolkit.level_2_comparisons import (
     get_action_expansion,
     get_coordination_scores,
@@ -29,6 +25,8 @@ from coauthor_interface.thought_toolkit.utils import (
     get_timestamp,
     sent_tokenize,
 )
+
+from coauthor_interface.thought_toolkit.active_plugins import ACTIVE_PLUGINS
 
 ########################
 
@@ -999,7 +997,7 @@ def parse_level_2_actions(level_1_actions_per_session, similarity_fcn):
 # This process involves:
 # - Tracking the latest accepted suggestions to align with user insertions.
 # - Identifying patterns like "mindless echo" and "mindless edit" of AI suggestions.
-# - Detecting topic shifts and counting new ideas.
+# - Detecting topic shifts and counting new ideas
 def parse_level_3_actions(level_2_actions_per_session, similarity_fcn):
     for session_key, actions_lst in level_2_actions_per_session.items():
         latest_accepted_suggestion = ""
@@ -1020,13 +1018,11 @@ def parse_level_3_actions(level_2_actions_per_session, similarity_fcn):
                 action["topic_shift"] = running_idea_count
 
             # Process text insert operations
-            if MajorInsertMindlessEchoPlugin.detection_detected(action):
-                action["level_3_action_type"] = MajorInsertMindlessEchoPlugin.get_plugin_name()
-                action_parsed = True
-
-            if not action_parsed and MinorInsertMindlessEditPlugin.detection_detected(action):
-                action["level_3_action_type"] = MinorInsertMindlessEditPlugin.get_plugin_name()
-                action_parsed = True
+            for plugin in ACTIVE_PLUGINS:
+                if plugin.detection_detected(action):
+                    action["level_3_action_type"] = plugin.get_plugin_name()
+                    action_parsed = True
+                    break
 
             # Handle topic shifts for text insertions
             if not action_parsed and action.get("level_1_action_type") == "insert_text":

--- a/tests/test_parse_all_consolidated.py
+++ b/tests/test_parse_all_consolidated.py
@@ -9,21 +9,32 @@ from coauthor_interface.backend.parse_all_consolidated import (
     action_type_priority_sort,
     process_logs,
 )
+from coauthor_interface.backend.PluginInterface import (
+    Plugin,
+    Intervention,
+    InterventionEnum,
+)
+
+
+@pytest.fixture
+def test_logs_file():
+    """Fixture providing a test logs file."""
+    return Path(__file__).parent / "small_logs_for_test.json"
 
 
 @pytest.fixture
 def raw_keylogs_from_frontend():
-    """Fixture providing sample raw keylogs from frontend for testing."""
+    """Fixture providing test keylogs data."""
     return {
         "session1": [
             {
-                "eventName": "suggestion-get",
+                "eventName": "text-insert",
                 "eventSource": "user",
-                "eventTimestamp": 1629357366346,
-                "textDelta": "",
+                "eventTimestamp": 1629357370478,
+                "textDelta": {"ops": [{"retain": 0}, {"insert": "test"}]},
                 "cursorRange": "",
                 "currentDoc": "",
-                "currentCursor": 379,
+                "currentCursor": 4,
                 "currentSuggestions": [],
                 "currentSuggestionIndex": 0,
                 "currentHoverIndex": "",
@@ -34,93 +45,17 @@ def raw_keylogs_from_frontend():
                 "currentPresencePenalty": "0",
                 "currentFrequencyPenalty": "0.5",
                 "eventNum": 1,
-            },
-            {
-                "eventName": "suggestion-open",
-                "eventSource": "api",
-                "eventTimestamp": 1629357368607,
-                "textDelta": "",
-                "cursorRange": "",
-                "currentDoc": "",
-                "currentCursor": 379,
-                "currentSuggestions": [
-                    {
-                        "index": 0,
-                        "original": " technology has made dating and relationships better.",
-                        "trimmed": "technology has made dating and relationships better.",
-                        "probability": 4.39569292539925e-12,
-                    },
-                    {
-                        "index": 1,
-                        "original": " technology has improved dating and relationships.",
-                        "trimmed": "technology has improved dating and relationships.",
-                        "probability": 4.65727687645238e-12,
-                    },
-                    {
-                        "index": 2,
-                        "original": " technology has made dating easier.",
-                        "trimmed": "technology has made dating easier.",
-                        "probability": 1.0105152942910267e-12,
-                    },
-                ],
-                "currentSuggestionIndex": 0,
-                "currentHoverIndex": "",
-                "currentN": "5",
-                "currentMaxToken": "30",
-                "currentTemperature": "0.2",
-                "currentTopP": "1",
-                "currentPresencePenalty": "0",
-                "currentFrequencyPenalty": "0.5",
-                "eventNum": 2,
-            },
-            {
-                "eventName": "suggestion-close",
-                "eventSource": "user",
-                "eventTimestamp": 1629357369818,
-                "textDelta": "",
-                "cursorRange": "",
-                "currentDoc": "",
-                "currentCursor": 379,
-                "currentSuggestions": [],
-                "currentSuggestionIndex": 0,
-                "currentHoverIndex": "",
-                "currentN": "5",
-                "currentMaxToken": "30",
-                "currentTemperature": "0.2",
-                "currentTopP": "1",
-                "currentPresencePenalty": "0",
-                "currentFrequencyPenalty": "0.5",
-                "eventNum": 3,
-            },
-            {
-                "eventName": "text-insert",
-                "eventSource": "user",
-                "eventTimestamp": 1629357370478,
-                "textDelta": {"ops": [{"retain": 379}, {"insert": " "}]},
-                "cursorRange": "",
-                "currentDoc": "",
-                "currentCursor": 380,
-                "currentSuggestions": [],
-                "currentSuggestionIndex": 0,
-                "currentHoverIndex": "",
-                "currentN": "5",
-                "currentMaxToken": "30",
-                "currentTemperature": "0.2",
-                "currentTopP": "1",
-                "currentPresencePenalty": "0",
-                "currentFrequencyPenalty": "0.5",
-                "eventNum": 4,
-            },
+            }
         ],
         "session2": [
             {
-                "eventName": "suggestion-get",
+                "eventName": "text-insert",
                 "eventSource": "user",
-                "eventTimestamp": 1629357366346,
-                "textDelta": "",
+                "eventTimestamp": 1629357370478,
+                "textDelta": {"ops": [{"retain": 0}, {"insert": "test"}]},
                 "cursorRange": "",
                 "currentDoc": "",
-                "currentCursor": 0,
+                "currentCursor": 4,
                 "currentSuggestions": [],
                 "currentSuggestionIndex": 0,
                 "currentHoverIndex": "",
@@ -133,75 +68,13 @@ def raw_keylogs_from_frontend():
                 "eventNum": 1,
             },
             {
-                "eventName": "suggestion-open",
-                "eventSource": "api",
-                "eventTimestamp": 1629357368607,
-                "textDelta": "",
-                "cursorRange": "",
-                "currentDoc": "",
-                "currentCursor": 0,
-                "currentSuggestions": [
-                    {
-                        "index": 0,
-                        "original": "The weather is beautiful today.",
-                        "trimmed": "The weather is beautiful today.",
-                        "probability": 4.39569292539925e-12,
-                    },
-                    {
-                        "index": 1,
-                        "original": "It's a perfect day for a walk.",
-                        "trimmed": "It's a perfect day for a walk.",
-                        "probability": 4.65727687645238e-12,
-                    },
-                    {
-                        "index": 2,
-                        "original": "The sun is shining brightly.",
-                        "trimmed": "The sun is shining brightly.",
-                        "probability": 1.0105152942910267e-12,
-                    },
-                ],
-                "currentSuggestionIndex": 0,
-                "currentHoverIndex": "",
-                "currentN": "5",
-                "currentMaxToken": "30",
-                "currentTemperature": "0.2",
-                "currentTopP": "1",
-                "currentPresencePenalty": "0",
-                "currentFrequencyPenalty": "0.5",
-                "eventNum": 2,
-            },
-            {
-                "eventName": "suggestion-close",
-                "eventSource": "user",
-                "eventTimestamp": 1629357369818,
-                "textDelta": "",
-                "cursorRange": "",
-                "currentDoc": "",
-                "currentCursor": 0,
-                "currentSuggestions": [],
-                "currentSuggestionIndex": 0,
-                "currentHoverIndex": "",
-                "currentN": "5",
-                "currentMaxToken": "30",
-                "currentTemperature": "0.2",
-                "currentTopP": "1",
-                "currentPresencePenalty": "0",
-                "currentFrequencyPenalty": "0.5",
-                "eventNum": 3,
-            },
-            {
                 "eventName": "text-insert",
                 "eventSource": "user",
                 "eventTimestamp": 1629357370478,
-                "textDelta": {
-                    "ops": [
-                        {"retain": 0},
-                        {"insert": "The weather is beautiful today."},
-                    ]
-                },
+                "textDelta": {"ops": [{"retain": 0}, {"insert": "test"}]},
                 "cursorRange": "",
                 "currentDoc": "",
-                "currentCursor": 28,
+                "currentCursor": 4,
                 "currentSuggestions": [],
                 "currentSuggestionIndex": 0,
                 "currentHoverIndex": "",
@@ -211,10 +84,50 @@ def raw_keylogs_from_frontend():
                 "currentTopP": "1",
                 "currentPresencePenalty": "0",
                 "currentFrequencyPenalty": "0.5",
-                "eventNum": 4,
+                "eventNum": 1,
             },
         ],
     }
+
+
+@pytest.fixture
+def mock_plugin():
+    """Fixture providing a mock plugin for testing."""
+
+    class MockPlugin(Plugin):
+        @staticmethod
+        def get_plugin_name() -> str:
+            return "mock_plugin"
+
+        @staticmethod
+        def detection_detected(action) -> bool:
+            return action.get("level_1_action_type") == "insert_text"
+
+        @staticmethod
+        def intervention_action() -> Intervention:
+            return Intervention(InterventionEnum.TOAST, "Mock plugin detected")
+
+    return MockPlugin()
+
+
+@pytest.fixture
+def mock_plugin2():
+    """Fixture providing another mock plugin for testing."""
+
+    class MockPlugin2(Plugin):
+        @staticmethod
+        def get_plugin_name() -> str:
+            return "mock_plugin2"
+
+        @staticmethod
+        def detection_detected(action) -> bool:
+            return action.get("level_1_action_type") == "delete_text"
+
+        @staticmethod
+        def intervention_action() -> Intervention:
+            return Intervention(InterventionEnum.TOAST, "Mock plugin 2 detected")
+
+    return MockPlugin2()
 
 
 @pytest.fixture
@@ -330,11 +243,13 @@ def test_action_type_priority_sort(raw_keylogs_from_frontend):
             assert isinstance(action["action_type"], str)
 
 
-def test_process_logs(raw_keylogs_from_frontend, fs, fake_output_dir):
+def test_process_logs(test_logs_file, fs, fake_output_dir):
     """Test the complete processing pipeline of raw keylogs using fake filesystem."""
     # Create a fake input file with raw keylogs
-    input_file = Path("/fake/input/raw_keylogs.json")
-    fs.create_file(input_file, contents=json.dumps(raw_keylogs_from_frontend))
+    # input_file = Path("/fake/input/raw_keylogs.json")
+    fs.add_real_file(test_logs_file)
+    input_file = test_logs_file
+    # fs.create_file(input_file, contents=json.dumps(test_logs_file))
 
     # Process the keylogs
     process_logs(input_file, fake_output_dir)
@@ -352,7 +267,7 @@ def test_process_logs(raw_keylogs_from_frontend, fs, fake_output_dir):
         assert output_file.exists()
 
         # Verify file contains valid JSON
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             data = json.load(f)
             assert isinstance(data, dict)
             assert len(data) > 0
@@ -377,13 +292,13 @@ def test_process_logs_invalid_json(fs, fake_output_dir):
         process_logs(input_file, fake_output_dir)
 
 
-def test_process_logs_output_dir_creation(fs, raw_keylogs_from_frontend):
+def test_process_logs_output_dir_creation(fs, test_logs_file):
     """Test that output directory is created if it doesn't exist when processing raw keylogs."""
-    input_file = Path("/fake/input/raw_keylogs.json")
     output_dir = Path("/fake/new/output/dir")
 
     # Create input file with raw keylogs
-    fs.create_file(input_file, contents=json.dumps(raw_keylogs_from_frontend))
+    fs.add_real_file(test_logs_file)
+    input_file = test_logs_file
 
     # Process keylogs - should create output directory
     process_logs(input_file, output_dir)
@@ -402,3 +317,126 @@ def test_process_logs_output_dir_creation(fs, raw_keylogs_from_frontend):
 
     for filename in expected_files:
         assert (output_dir / filename).exists()
+
+
+def test_process_logs_with_plugins(
+    test_logs_file, fs, fake_output_dir, monkeypatch, mock_plugin, mock_plugin2
+):
+    """Test processing logs with active plugins."""
+    # Mock the ACTIVE_PLUGINS list in both places where it's used
+    monkeypatch.setattr(
+        "coauthor_interface.backend.parse_all_consolidated.ACTIVE_PLUGINS",
+        [mock_plugin, mock_plugin2],
+    )
+    monkeypatch.setattr(
+        "coauthor_interface.thought_toolkit.parser_all_levels.ACTIVE_PLUGINS",
+        [mock_plugin, mock_plugin2],
+    )
+
+    fs.add_real_file(test_logs_file)
+    input_file = test_logs_file
+
+    # Process the keylogs
+    process_logs(input_file, fake_output_dir)
+
+    # Check that the output file with priority actions exists
+    output_file = fake_output_dir / "action_type_with_priority_per_session.json"
+    assert output_file.exists()
+
+    # Verify the priority actions contain plugin names
+    with open(output_file, encoding="utf-8") as f:
+        data = json.load(f)
+        assert isinstance(data, dict)
+        assert len(data) > 0
+
+        # Debug: Print all level_3_action_types found
+        all_level_3_types = set()
+        for session_actions in data.values():
+            for action in session_actions:
+                if "level_3_action_type" in action:
+                    all_level_3_types.add(action["level_3_action_type"])
+        print(f"Found level_3_action_types: {all_level_3_types}")
+
+        # Check that plugin names are logged in the output file
+        for session_actions in data.values():
+            for action in session_actions:
+                if "level_3_action_type" in action:
+                    # Debug: Print action details if it doesn't match expected plugin names
+                    if action["level_3_action_type"] not in [
+                        mock_plugin.get_plugin_name(),
+                        mock_plugin2.get_plugin_name(),
+                    ]:
+                        print(f"Unexpected action: {action}")
+                    assert action["level_3_action_type"] in [
+                        mock_plugin.get_plugin_name(),
+                        mock_plugin2.get_plugin_name(),
+                    ]
+
+
+def test_process_logs_with_empty_plugins(test_logs_file, fs, fake_output_dir, monkeypatch):
+    """Test processing logs with empty ACTIVE_PLUGINS list."""
+    # Mock the ACTIVE_PLUGINS list to be empty in both places
+    monkeypatch.setattr("coauthor_interface.backend.parse_all_consolidated.ACTIVE_PLUGINS", [])
+    monkeypatch.setattr("coauthor_interface.thought_toolkit.parser_all_levels.ACTIVE_PLUGINS", [])
+
+    # Create input file with raw keylogs
+    fs.add_real_file(test_logs_file)
+    input_file = test_logs_file
+
+    # Process the keylogs - should not raise any errors
+    process_logs(input_file, fake_output_dir)
+
+    # Check that the output file with priority actions exists
+    output_file = fake_output_dir / "action_type_with_priority_per_session.json"
+    assert output_file.exists()
+
+    # Verify the file contains valid JSON
+    with open(output_file, encoding="utf-8") as f:
+        data = json.load(f)
+        assert isinstance(data, dict)
+        assert len(data) > 0
+
+
+def test_plugin_detection_called(test_logs_file, fs, fake_output_dir, monkeypatch, mock_plugin):
+    """Test that plugin detection_detected method is called during processing."""
+    # Create input file with raw keylogs
+    fs.add_real_file(test_logs_file)
+    input_file = test_logs_file
+
+    # Create a spy for the detection_detected method
+    detection_called = False
+
+    def mock_detection_detected(action):
+        nonlocal detection_called
+        detection_called = True
+        return mock_plugin.detection_detected(action)
+
+    # Create a modified mock plugin with the spy
+    class SpyMockPlugin(Plugin):
+        @staticmethod
+        def get_plugin_name() -> str:
+            return mock_plugin.get_plugin_name()
+
+        @staticmethod
+        def detection_detected(action):
+            return mock_detection_detected(action)
+
+        @staticmethod
+        def intervention_action() -> Intervention:
+            return mock_plugin.intervention_action()
+
+    # Mock the ACTIVE_PLUGINS list with our spy plugin in both places
+    monkeypatch.setattr(
+        "coauthor_interface.backend.parse_all_consolidated.ACTIVE_PLUGINS",
+        [SpyMockPlugin()],
+    )
+    monkeypatch.setattr(
+        "coauthor_interface.thought_toolkit.parser_all_levels.ACTIVE_PLUGINS",
+        [SpyMockPlugin()],
+    )
+
+    # Process the keylogs
+    process_logs(input_file, fake_output_dir)
+
+    # Verify that detection_detected was called
+    assert detection_called, "Plugin detection_detected method was not called during processing"


### PR DESCRIPTION
## :pencil: Description
Refactor L3 analysis plugins to use interface
- refactor for both post-experiment session analysis and parse_logs route

Currently, the detection of level 3 actions and recording of detected level 3 actions into the annotated logs is hard-coded. We want to replace this hard-coding with automatically checking for all Level 3 actions within a specific python file.

## :gear: Work Item
https://dev.azure.com/gt-sse-center/CoAuthor/_workitems/edit/696/
