### PR TITLE
[699] Add researcher notes in session metadata

### DIFF
--- a/src/coauthor_interface/backend/api_server.py
+++ b/src/coauthor_interface/backend/api_server.py
@@ -116,6 +116,7 @@ def start_session():
         "intervention": "alert_writer",
     }
     SESSIONS[session_id].update(config.convert_to_dict())
+    SESSIONS[session_id]["researcher_notes"] = ""
 
     result["status"] = SUCCESS
 


### PR DESCRIPTION
## Description
Add a "researcher_notes" field in the metadata for each session where researchers can go in after sessions and add their own notes

## Work Item
https://dev.azure.com/gt-sse-center/CoAuthor/_workitems/edit/699/

## Demo
<img width="775" alt="Screenshot 2025-06-10 at 3 49 07 PM" src="https://github.com/user-attachments/assets/6434ce83-9775-448f-a4eb-185a4330133c" />
